### PR TITLE
task/change bullets to switch on click instead of hover

### DIFF
--- a/src/components/DeviceImage/index.scss
+++ b/src/components/DeviceImage/index.scss
@@ -49,6 +49,13 @@
 
       @media screen and (min-width: 768px) {
         width: 68.45%;
+        top: 1.5vw;
+        height: 24.3vw;
+      }
+
+      @media screen and (min-width: 600px) and (max-height: 700px) {
+        top: 5.2%;
+        width: 68.45%;
         height: 74%;
       }
     }

--- a/src/components/ProjectDashboard/index.js
+++ b/src/components/ProjectDashboard/index.js
@@ -15,7 +15,7 @@ const propTypes = {
 };
 
 export class ProjectDashboard extends Component {
-  constructor(props) {
+  constructor (props) {
     super(props);
     this.handleKeyDown = this.handleKeyDown.bind(this);
     this.handleSwipeAction = this.handleSwipeAction.bind(this);

--- a/src/components/ProjectDashboard/index.scss
+++ b/src/components/ProjectDashboard/index.scss
@@ -13,7 +13,7 @@
 
     &--desktop {
       @media screen and (min-width: 600px) {
-        width: 90vh;
+        width: 90%;
         margin-left: -(((100% - $base-width) * .5) + 6%);
       }
 
@@ -28,6 +28,10 @@
 
       @media screen and (min-width: 1440px) {
         margin-top: 2vh;
+      }
+
+      @media screen and (min-width: 600px) and (max-height: 700px) {
+        width: 90vh;
       }
     }
   }

--- a/src/components/SideBar/Bullets/index-test.js
+++ b/src/components/SideBar/Bullets/index-test.js
@@ -27,20 +27,22 @@ describe('Bullets', () => {
     })
   ]);
   const project = projects.last();
+  let bullets;
+
+  beforeEach(() => {
+    bullets = new Bullets();
+    bullets.props = {
+      isActiveProject: (currentProject, activeProject) => {
+        return activeProject.get('id') === currentProject.get('id');
+      },
+      activeProject: project
+    };
+  });
 
   describe('bulletClassName', () => {
     let bulletClassName;
-    let bullets;
 
     beforeEach(() => {
-      bullets = new Bullets();
-      bullets.props = {
-        isActiveProject: (currentProject, activeProject) => {
-          return activeProject.get('id') === currentProject.get('id');
-        },
-        activeProject: project
-      };
-
       bulletClassName = bullets.bulletClassName(projects.last());
     });
 
@@ -50,13 +52,11 @@ describe('Bullets', () => {
   });
 
   describe('bulletStyles', () => {
-    let bullets;
     let getColor;
     const colorSets = new List([]);
 
     beforeEach(() => {
       getColor = spy(ProjectHelpers, 'getColor');
-      bullets = new Bullets();
 
       bullets.props = {
         isActiveProject: (currentProject, activeProject) => {
@@ -70,6 +70,41 @@ describe('Bullets', () => {
     it('calls getColor if the project is the activeProject', () => {
       bullets.bulletStyles(project);
       expect(getColor.calledOnce).to.be.true;
+    });
+  });
+
+  describe('bulletIsToBeHighlighted', () => {
+    let isActiveProject;
+
+    it('returns true if state.hover is the project in question', () => {
+      isActiveProject = stub(bullets.props, 'isActiveProject').returns(false);
+      bullets.state = {
+        hover: project
+      };
+
+      expect(bullets.bulletIsToBeHighlighted(project)).to.be.true;
+    });
+
+    it('returns true if state.hover is not the project in question but the project is active', () => {
+      isActiveProject = stub(bullets.props, 'isActiveProject').returns(true);
+      bullets.state = {
+        hover: null
+      };
+
+      expect(bullets.bulletIsToBeHighlighted(project)).to.be.true;
+    });
+
+    it('returns false if state.hover is not the project in question and the project is not active', () => {
+      isActiveProject = stub(bullets.props, 'isActiveProject').returns(false);
+      bullets.state = {
+        hover: null
+      };
+
+      expect(bullets.bulletIsToBeHighlighted(project)).to.be.false;
+    });
+
+    afterEach(() => {
+      isActiveProject.restore();
     });
   });
 });

--- a/src/components/SideBar/Bullets/index.js
+++ b/src/components/SideBar/Bullets/index.js
@@ -15,6 +15,7 @@ const propTypes = {
 class Bullets extends Component {
   constructor (props) {
     super(props);
+    this.state = { hover: null };
   }
 
   path () {
@@ -28,13 +29,17 @@ class Bullets extends Component {
   }
 
   bulletClassName (project) {
-    return this.props.isActiveProject(project, this.props.activeProject) ?
+    return this.bulletIsToBeHighlighted(project) ?
       'side-bar__bullet side-bar__bullet--active' :
       'side-bar__bullet';
   }
 
+  bulletIsToBeHighlighted (project) {
+    return this.props.isActiveProject(project, this.props.activeProject) || this.state.hover === project;
+  }
+
   bulletStyles (project) {
-    if (this.props.isActiveProject(project, this.props.activeProject)) {
+    if (this.bulletIsToBeHighlighted(project)) {
       const color = getColor(
         project,
         this.props.colorSets,
@@ -50,13 +55,18 @@ class Bullets extends Component {
     return {};
   }
 
+  handleMouseOver (project) {
+    return this.setState({ hover: project });
+  }
+
   displayBullets () {
     return this.props.projects.map((project, index) => {
       return (
         <li
           style={this.bulletStyles(project)}
           className={this.bulletClassName(project)}
-          onMouseOver={() => {this.props.setActiveProject(project);}}
+          onMouseOver={() => {this.setState({ hover: project });}}
+          onMouseOut={() => {this.setState({ hover: null });}}
           onClick={() => {this.props.setActiveProject(project);}}
           key={index + 5000}
         >


### PR DESCRIPTION
- Made a quick change to device images on desktop
- Added `bulletIsToBeHighlighted` to handle cases of `--active` or hover
- Removed former handling of `onMouseOver`